### PR TITLE
feat(context): add ContextOptions with eval_threads for BDD eval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,24 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  rust:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-      - run: cargo build --verbose
-      - run: cargo test --verbose
+          components: rustfmt, clippy
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: cargo clippy (all features)
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: cargo test
+        run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The public API is identical regardless of which backend is selected.
 - [ ] Identity / noise refresh: [#11](https://github.com/cedoor/squid/issues/11)
 - [ ] NTT backend: [#12](https://github.com/cedoor/squid/issues/12)
 - [ ] Key serialization: [#13](https://github.com/cedoor/squid/issues/13)
+- [ ] Faster tests via fixtures or deterministic keygen: [#19](https://github.com/cedoor/squid/issues/19)
+- [ ] Refactor `context.rs`: [#20](https://github.com/cedoor/squid/issues/20)
 
 ### Milestone 3 — Developer Experience: [#3](https://github.com/cedoor/squid/milestone/3)
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -266,8 +266,7 @@ impl Context {
         assert_eval_threads(options.eval_threads);
         self.options = options;
         if self.params.scratch_bytes.is_none() {
-            let bytes =
-                compute_arena_bytes(&self.module, &self.params, self.options.eval_threads);
+            let bytes = compute_arena_bytes(&self.module, &self.params, self.options.eval_threads);
             self.arena = scratch::new_arena(bytes);
         }
         self
@@ -292,8 +291,7 @@ impl Context {
         assert_eval_threads(options.eval_threads);
         self.options = options;
         if self.params.scratch_bytes.is_none() {
-            let bytes =
-                compute_arena_bytes(&self.module, &self.params, self.options.eval_threads);
+            let bytes = compute_arena_bytes(&self.module, &self.params, self.options.eval_threads);
             self.arena = scratch::new_arena(bytes);
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,9 +6,9 @@
 //! ## Typical workflow
 //!
 //! ```rust,no_run
-//! use squid::{Context, Params};
+//! use squid::{Context, ContextOptions, Params};
 //!
-//! let mut ctx = Context::new(Params::unsecure());
+//! let mut ctx = Context::new(Params::unsecure()).with_options(ContextOptions::default());
 //! let (sk, ek) = ctx.keygen();
 //!
 //! let a = ctx.encrypt::<u32>(42, &sk);
@@ -47,6 +47,32 @@ use crate::{
 /// No generic backend parameter surfaces in squid's public API.
 type Mod = Module<crate::backend::BE>;
 
+#[inline]
+fn assert_eval_threads(n: usize) {
+    assert!(n >= 1, "eval_threads must be >= 1, got {n}");
+}
+
+// ── ContextOptions ───────────────────────────────────────────────────────────
+
+/// Runtime options for a [`Context`], separate from cryptographic [`Params`].
+///
+/// Pass to [`Context::with_options`] after [`Context::new`], or use
+/// [`ContextOptions::default`] for single-threaded BDD evaluation.  Invalid
+/// `eval_threads` (0) is rejected when options are applied ([`Context::with_options`],
+/// [`Context::set_options`], [`Params::min_scratch_bytes`]).
+#[derive(Debug, Clone)]
+pub struct ContextOptions {
+    /// OS threads used for BDD circuit evaluation (CMux phase) on homomorphic
+    /// binary ops.  **Default 1.**
+    pub eval_threads: usize,
+}
+
+impl Default for ContextOptions {
+    fn default() -> Self {
+        Self { eval_threads: 1 }
+    }
+}
+
 // ── Params ───────────────────────────────────────────────────────────────────
 
 /// Parameter set for a [`Context`].
@@ -55,9 +81,10 @@ type Mod = Module<crate::backend::BE>;
 /// evaluation.  [`Params::unsecure`] matches Poulpy's `bdd_arithmetic` example
 /// (n = 1024) and is **not** presented as a vetted security level.
 ///
-/// Advanced users may construct custom `Params` directly, but must ensure
-/// consistency across all layout fields — concretely, `n_glwe`, `base2k`, and
-/// `rank` must agree everywhere they appear.
+/// Advanced users may construct custom `Params` directly (often with struct
+/// update syntax, e.g. `Params { n_glwe: 2048, ..Params::unsecure() }`), but
+/// must ensure consistency across all layout fields — concretely, `n_glwe`,
+/// `base2k`, and `rank` must agree everywhere they appear.
 #[derive(Debug, Clone)]
 pub struct Params {
     /// GLWE ring degree (must be a power of two; determines the ring Z_q[X]/(X^n+1)).
@@ -161,6 +188,23 @@ impl Params {
             scratch_bytes: None,
         }
     }
+
+    /// Minimum scratch arena size (in bytes) for this [`Params`] bundle with
+    /// the given [`ContextOptions`] (e.g. multi-threaded BDD evaluation).
+    ///
+    /// Use with [`Params::scratch_bytes`] when you need an explicit size, or
+    /// leave `scratch_bytes` as `None` so [`Context::new`] sizes the arena
+    /// automatically (using the options passed to [`Context::with_options`], or
+    /// [`ContextOptions::default`]).
+    ///
+    /// # Panics
+    ///
+    /// If `options.eval_threads` is zero.
+    pub fn min_scratch_bytes(&self, options: &ContextOptions) -> usize {
+        assert_eval_threads(options.eval_threads);
+        let module = Mod::new(self.n_glwe as u64);
+        compute_arena_bytes(&module, self, options.eval_threads)
+    }
 }
 
 // ── Context ──────────────────────────────────────────────────────────────────
@@ -180,23 +224,77 @@ pub struct Context {
     params: Params,
     module: Mod,
     arena: scratch::Arena,
+    options: ContextOptions,
 }
 
 impl Context {
     /// Create a new context with the given parameter set.
     ///
+    /// Uses [`ContextOptions::default`] (single-threaded BDD evaluation).  Chain
+    /// [`Context::with_options`] to change that, e.g.
+    /// `Context::new(params).with_options(ContextOptions { eval_threads: 4, ..Default::default() })`.
+    ///
     /// Allocates the FFT tables and scratch arena.  This is the most expensive
     /// one-time setup cost; key generation and evaluation are the runtime costs.
     pub fn new(params: Params) -> Self {
+        let options = ContextOptions::default();
+        assert_eval_threads(options.eval_threads);
         let module = Mod::new(params.n_glwe as u64);
         let bytes = params
             .scratch_bytes
-            .unwrap_or_else(|| compute_arena_bytes(&module, &params));
+            .unwrap_or_else(|| compute_arena_bytes(&module, &params, options.eval_threads));
         let arena = scratch::new_arena(bytes);
         Context {
             params,
             module,
             arena,
+            options,
+        }
+    }
+
+    /// Applies runtime options, replacing any previous [`ContextOptions`].
+    ///
+    /// If [`Params::scratch_bytes`] is `None`, reallocates the scratch arena to
+    /// match (via [`Params::min_scratch_bytes`]).  If `scratch_bytes` was set
+    /// explicitly, the arena is **not** resized; ensure it remains large enough,
+    /// or BDD evaluation may panic.
+    ///
+    /// # Panics
+    ///
+    /// If `options.eval_threads` is zero.
+    pub fn with_options(mut self, options: ContextOptions) -> Self {
+        assert_eval_threads(options.eval_threads);
+        self.options = options;
+        if self.params.scratch_bytes.is_none() {
+            let bytes =
+                compute_arena_bytes(&self.module, &self.params, self.options.eval_threads);
+            self.arena = scratch::new_arena(bytes);
+        }
+        self
+    }
+
+    /// Returns a copy of the current [`ContextOptions`].
+    pub fn options(&self) -> ContextOptions {
+        self.options.clone()
+    }
+
+    /// BDD evaluation thread count from the active [`ContextOptions`].
+    pub fn eval_threads(&self) -> usize {
+        self.options.eval_threads
+    }
+
+    /// Updates runtime options in place (same rules as [`Context::with_options`]).
+    ///
+    /// # Panics
+    ///
+    /// If `options.eval_threads` is zero.
+    pub fn set_options(&mut self, options: ContextOptions) {
+        assert_eval_threads(options.eval_threads);
+        self.options = options;
+        if self.params.scratch_bytes.is_none() {
+            let bytes =
+                compute_arena_bytes(&self.module, &self.params, self.options.eval_threads);
+            self.arena = scratch::new_arena(bytes);
         }
     }
 
@@ -299,6 +397,8 @@ impl Context {
     /// 1. Allocate and populate `FheUintPrepared` for `a` and `b`.
     /// 2. Allocate output `FheUint`.
     /// 3. Invoke `op` on it.
+    ///
+    /// Uses [`ContextOptions::eval_threads`] for Poulpy's `*_multi_thread` BDD evaluators.
     fn eval_binary<T, F>(
         &mut self,
         a: &Ciphertext<T>,
@@ -310,6 +410,7 @@ impl Context {
         T: UnsignedInteger,
         F: FnOnce(
             &Mod,
+            usize,
             &mut FheUint<Vec<u8>, T>,
             &FheUintPrepared<Vec<u8>, T, crate::backend::BE>,
             &FheUintPrepared<Vec<u8>, T, crate::backend::BE>,
@@ -317,6 +418,7 @@ impl Context {
             &mut poulpy_hal::layouts::Scratch<crate::backend::BE>,
         ),
     {
+        let eval_threads = self.options.eval_threads;
         let mut a_prep: FheUintPrepared<Vec<u8>, T, crate::backend::BE> =
             FheUintPrepared::alloc_from_infos(&self.module, &self.params.ggsw_layout);
         a_prep.prepare::<CGGI, _, _, _, _>(
@@ -338,6 +440,7 @@ impl Context {
         let mut out: FheUint<Vec<u8>, T> = FheUint::alloc_from_infos(&self.params.glwe_layout);
         op(
             &self.module,
+            eval_threads,
             &mut out,
             &a_prep,
             &b_prep,
@@ -360,8 +463,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: Add<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.add(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.add_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 
@@ -376,8 +479,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: Sub<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.sub(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.sub_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 
@@ -392,8 +495,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: And<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.and(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.and_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 
@@ -408,8 +511,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: Or<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.or(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.or_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 
@@ -424,8 +527,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: Xor<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.xor(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.xor_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 
@@ -440,8 +543,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: Sll<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.sll(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.sll_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 
@@ -456,8 +559,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: Srl<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.srl(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.srl_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 
@@ -472,8 +575,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: Sra<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.sra(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.sra_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 
@@ -488,8 +591,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: Slt<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.slt(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.slt_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 
@@ -504,8 +607,8 @@ impl Context {
         T: UnsignedInteger,
         FheUint<Vec<u8>, T>: Sltu<T, crate::backend::BE>,
     {
-        self.eval_binary(a, b, ek, |module, out, ap, bp, key, scratch| {
-            out.sltu(module, ap, bp, key, scratch);
+        self.eval_binary(a, b, ek, |module, threads, out, ap, bp, key, scratch| {
+            out.sltu_multi_thread(threads, module, ap, bp, key, scratch);
         })
     }
 }
@@ -516,7 +619,7 @@ impl Context {
 /// pipeline by taking the `max` across every scratch-taking category.
 /// The arena is reused sequentially, so the worst-case single operation
 /// determines the required size.
-fn compute_arena_bytes(module: &Mod, params: &Params) -> usize {
+fn compute_arena_bytes(module: &Mod, params: &Params, eval_threads: usize) -> usize {
     let keygen_encrypt = module.bdd_key_encrypt_sk_tmp_bytes(&params.bdd_layout);
     let keygen_prepare = module.prepare_bdd_key_tmp_bytes(&params.bdd_layout);
     let fhe_prepare = module.fhe_uint_prepare_tmp_bytes(
@@ -541,17 +644,18 @@ fn compute_arena_bytes(module: &Mod, params: &Params) -> usize {
         BDDKeyPrepared::alloc_from_infos(module, &params.bdd_layout);
     let g = &params.ggsw_layout;
     let r = &params.glwe_layout;
+    let t = eval_threads;
     let eval = [
-        dummy.add_tmp_bytes(module, r, g, &bdd_key_prepared),
-        dummy.sub_tmp_bytes(module, r, g, &bdd_key_prepared),
-        dummy.and_tmp_bytes(module, r, g, &bdd_key_prepared),
-        dummy.or_tmp_bytes(module, r, g, &bdd_key_prepared),
-        dummy.xor_tmp_bytes(module, r, g, &bdd_key_prepared),
-        dummy.sll_tmp_bytes(module, r, g, &bdd_key_prepared),
-        dummy.srl_tmp_bytes(module, r, g, &bdd_key_prepared),
-        dummy.sra_tmp_bytes(module, r, g, &bdd_key_prepared),
-        dummy.slt_tmp_bytes(module, r, g, &bdd_key_prepared),
-        dummy.sltu_tmp_bytes(module, r, g, &bdd_key_prepared),
+        dummy.add_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
+        dummy.sub_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
+        dummy.and_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
+        dummy.or_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
+        dummy.xor_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
+        dummy.sll_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
+        dummy.srl_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
+        dummy.sra_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
+        dummy.slt_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
+        dummy.sltu_multi_thread_tmp_bytes(module, t, r, g, &bdd_key_prepared),
     ]
     .into_iter()
     .max()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,5 @@ pub mod keys;
 pub mod scratch;
 
 pub use ciphertext::Ciphertext;
-pub use context::{Context, Params};
+pub use context::{Context, ContextOptions, Params};
 pub use keys::{EvaluationKey, SecretKey};

--- a/tests/bdd_parallel.rs
+++ b/tests/bdd_parallel.rs
@@ -1,0 +1,19 @@
+use squid::{Context, ContextOptions, Params};
+
+#[test]
+fn eval_threads_two_matches_one() {
+    let params = Params::unsecure();
+
+    let mut ctx1 = Context::new(params.clone());
+    let mut ctx2 = Context::new(params).with_options(ContextOptions { eval_threads: 2 });
+
+    let (sk, ek) = ctx1.keygen();
+
+    let ct_a = ctx1.encrypt(7u32, &sk);
+    let ct_b = ctx1.encrypt(5u32, &sk);
+
+    let c1 = ctx1.add(&ct_a, &ct_b, &ek);
+    let c2 = ctx2.add(&ct_a, &ct_b, &ek);
+
+    assert_eq!(ctx1.decrypt(&c1, &sk), ctx2.decrypt(&c2, &sk));
+}


### PR DESCRIPTION
- Add ContextOptions (default eval_threads=1), with_options/set_options on Context
- Size scratch arena from eval_threads; add Params::min_scratch_bytes
- Document Params customization via struct update syntax
- Add bdd_parallel integration test (two threads vs one, same decrypt)
- README: roadmap items for faster tests and context refactor