### PR TITLE
test(squid): add integration test for all BDD homomorphic ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ All operations currently require `T = u32` (the only width with compiled BDD cir
 | `ctx.slt(a, b, ek)`  | Signed less-than       |
 | `ctx.sltu(a, b, ek)` | Unsigned less-than     |
 
+Integration tests in [`crates/squid/tests/bdd_ops.rs`](crates/squid/tests/bdd_ops.rs) exercise every method in the table above on `u32` with `Params::test()` and deterministic seeds; run them with `cargo test -p squid`.
+
 ## Backends
 
 | Feature       | Backend    | Notes                           |
@@ -169,7 +171,7 @@ The public API is identical regardless of which backend is selected.
 - [x] Set up GitHub Actions (cargo test, cargo clippy, cargo fmt check): [#3](https://github.com/cedoor/squid/issues/3)
 - [x] Release first alpha version: [#5](https://github.com/cedoor/squid/issues/5)
 - [x] Add at least one runnable example in examples/: [#7](https://github.com/cedoor/squid/issues/7)
-- [ ] Add tests for all existing ops: [#4](https://github.com/cedoor/squid/issues/4)
+- [x] Add tests for all existing ops: [#4](https://github.com/cedoor/squid/issues/4)
 - [ ] Add rustdoc comments to all public items: [#6](https://github.com/cedoor/squid/issues/6)
 - [x] Faster tests via fixtures or deterministic keygen: [#19](https://github.com/cedoor/squid/issues/19)
 

--- a/crates/squid/tests/bdd_ops.rs
+++ b/crates/squid/tests/bdd_ops.rs
@@ -1,0 +1,51 @@
+mod common;
+
+use squid::{Context, Params};
+
+use common::TEST_SEEDS;
+
+#[test]
+fn bdd_homomorphic_ops_match_u32_plaintext() {
+    let mut ctx = Context::new(Params::test());
+    let (sk, ek) = ctx.keygen_from_seeds(TEST_SEEDS);
+
+    let a: u32 = 0xcafe_babe;
+    let b: u32 = 5;
+    let ct_a = ctx.encrypt(a, &sk);
+    let ct_b = ctx.encrypt(b, &sk);
+
+    let c_add = ctx.add(&ct_a, &ct_b, &ek);
+    assert_eq!(ctx.decrypt(&c_add, &sk), a.wrapping_add(b));
+
+    let c_sub = ctx.sub(&ct_a, &ct_b, &ek);
+    assert_eq!(ctx.decrypt(&c_sub, &sk), a.wrapping_sub(b));
+
+    let c_and = ctx.and(&ct_a, &ct_b, &ek);
+    assert_eq!(ctx.decrypt(&c_and, &sk), a & b);
+
+    let c_or = ctx.or(&ct_a, &ct_b, &ek);
+    assert_eq!(ctx.decrypt(&c_or, &sk), a | b);
+
+    let c_xor = ctx.xor(&ct_a, &ct_b, &ek);
+    assert_eq!(ctx.decrypt(&c_xor, &sk), a ^ b);
+
+    let c_sll = ctx.sll(&ct_a, &ct_b, &ek);
+    assert_eq!(ctx.decrypt(&c_sll, &sk), a.wrapping_shl(b));
+
+    let c_srl = ctx.srl(&ct_a, &ct_b, &ek);
+    assert_eq!(ctx.decrypt(&c_srl, &sk), a.wrapping_shr(b));
+
+    let c_sra = ctx.sra(&ct_a, &ct_b, &ek);
+    assert_eq!(
+        ctx.decrypt(&c_sra, &sk),
+        ((a as i32).wrapping_shr(b)) as u32
+    );
+
+    let c_slt = ctx.slt(&ct_a, &ct_b, &ek);
+    let exp_slt = u32::from((a as i32) < (b as i32));
+    assert_eq!(ctx.decrypt(&c_slt, &sk), exp_slt);
+
+    let c_sltu = ctx.sltu(&ct_a, &ct_b, &ek);
+    let exp_sltu = u32::from(a < b);
+    assert_eq!(ctx.decrypt(&c_sltu, &sk), exp_sltu);
+}


### PR DESCRIPTION
Adds `crates/squid/tests/bdd_ops.rs`: one deterministic integration test that runs every `Context` BDD op on `u32` (add, sub, and, or, xor, sll, srl, sra, slt, sltu) and checks decrypted results against plain Rust semantics.

Uses `Params::test()` and shared `TEST_SEEDS` with the other integration tests; two ciphertexts are reused across ops to limit redundant encrypt work.

Fixes #4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive integration test validating homomorphic operations (add, subtract, bitwise AND/OR/XOR, shifts, and comparisons) on deterministic test vectors to ensure encrypted results match plaintext behavior.
* **Documentation**
  * Updated README to document where the BDD integration tests live, how to run them, and mark the “Add tests for all existing ops” milestone as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->