### PR TITLE
docs: CHANGELOG, v0.1.0-alpha.2, release notes workflow

### DIFF
--- a/.cursor/rules/changelog.mdc
+++ b/.cursor/rules/changelog.mdc
@@ -1,0 +1,19 @@
+---
+description: CHANGELOG and release notes (Keep a Changelog)
+globs: CHANGELOG.md
+alwaysApply: true
+---
+
+# Changelog
+
+The repo keeps a root [`CHANGELOG.md`](CHANGELOG.md) in [Keep a Changelog](https://keepachangelog.com/) style.
+
+## When a PR is merged
+
+- Add a bullet under **`## [Unreleased]`** describing the user-facing or notable change (Added / Changed / Fixed / etc. as appropriate). Do this in the same PR that introduces the change when possible.
+- That section is the draft for the **next** version: at release time, its contents are moved under a new dated `## [x.y.z] - YYYY-MM-DD` heading and `[Unreleased]` is left ready for the following cycle.
+
+## Releases
+
+- Version bumps and Git tags should match the sections you add to `CHANGELOG.md`.
+- Link references at the bottom of `CHANGELOG.md` must be updated when cutting a release (compare URLs for the new tag).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for published Rust crates and npm packages.
+
+## [Unreleased]
+
+## [0.1.0-alpha.2] - 2026-04-28
+
+### Added
+
+- `CHANGELOG.md` to track releases in Keep a Changelog format ([#26](https://github.com/cedoor/squid/issues/26)).
+
+[Unreleased]: https://github.com/cedoor/squid/compare/v0.1.0-alpha.2...HEAD
+[0.1.0-alpha.2]: https://github.com/cedoor/squid/compare/v0.1.0-alpha.1...v0.1.0-alpha.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,4 @@ Developer guide for AI assistants working in this repo. Detailed rules live in `
 | [constraints.mdc](.cursor/rules/constraints.mdc) | Hard constraints — what NOT to do |
 | [squid-js.mdc](.cursor/rules/squid-js.mdc) | squid-js TypeScript package, WASM/NAPI shims, build process |
 | [demo.mdc](.cursor/rules/demo.mdc) | Demo Next.js app and Playwright e2e conventions |
+| [changelog.mdc](.cursor/rules/changelog.mdc) | `CHANGELOG.md` (Keep a Changelog), **`[Unreleased]`** on each merge, release flow |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "squid"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "getrandom 0.3.4",
  "poulpy-core",

--- a/crates/squid/Cargo.toml
+++ b/crates/squid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squid"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 description = "An ergonomic Rust wrapper for Poulpy FHE."
 license = "MIT"


### PR DESCRIPTION
## Summary

- Adds root `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/) format and documents **v0.1.0-alpha.2** (this change set).
- Bumps the published `squid` crate to `0.1.0-alpha.2`.
- Adds `.cursor/rules/changelog.mdc`: merge PRs should append to **`## [Unreleased]`**; that block is promoted when cutting the next version.
- Registers the rule in `CLAUDE.md`.

Closes #26.

## Post-merge

Tag and GitHub Release for `v0.1.0-alpha.2` should be created from `main` after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `CHANGELOG.md` documenting release history and version changes.

* **Chores**
  * Bumped package version to `0.1.0-alpha.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->